### PR TITLE
Failure: Use Reference Equality for SourceException

### DIFF
--- a/src/core-taggeds-failure/Failure/Failure.T/Failure.T.Equality.Common.cs
+++ b/src/core-taggeds-failure/Failure/Failure.T/Failure.T.Equality.Common.cs
@@ -12,7 +12,7 @@ partial struct Failure<TFailureCode>
         =>
         StringComparer.Ordinal;
 
-    private static EqualityComparer<Exception> SourceExceptionComparer
+    private static ReferenceEqualityComparer SourceExceptionComparer
         =>
-        EqualityComparer<Exception>.Default;
+        ReferenceEqualityComparer.Instance;
 }


### PR DESCRIPTION
`Failure` improvements:

- Use Reference Equality for `SourceException`