### PR TITLE
release/v2.2.0-preview.7

### DIFF
--- a/src/core-taggeds-optional/Optional/Optional.csproj
+++ b/src/core-taggeds-optional/Optional/Optional.csproj
@@ -17,7 +17,7 @@
     <Description>PrimeFuncPack Core.Optional is a core library for .NET consisting of Optional monad targeted for use in functional programming.</Description>
     <RootNamespace>System</RootNamespace>
     <AssemblyName>PrimeFuncPack.Core.Optional</AssemblyName>
-    <Version>2.2.0-preview.2</Version>
+    <Version>2.2.0-preview.3</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/core-taggeds-optional/Optional/OptionalLinqExtensions/Inner/InnerElementAtOrAbsent.cs
+++ b/src/core-taggeds-optional/Optional/OptionalLinqExtensions/Inner/InnerElementAtOrAbsent.cs
@@ -8,23 +8,19 @@ partial class OptionalLinqExtensions
         this IEnumerable<TSource> source,
         Index index)
         =>
-        index.IsFromEnd switch
+        source switch
         {
-            not true => source.InnerElementAtOrAbsent(index.Value),
+            IReadOnlyList<TSource> list
+            =>
+            list.InnerElementAtOrAbsent_IReadOnlyList(index.GetOffset(list.Count)),
 
-            _ => source switch
-            {
-                IReadOnlyList<TSource> list
-                =>
-                list.InnerElementAtOrAbsent_IReadOnlyList(list.Count - index.Value),
+            IList<TSource> list
+            =>
+            list.InnerElementAtOrAbsent_IList(index.GetOffset(list.Count)),
 
-                IList<TSource> list
-                =>
-                list.InnerElementAtOrAbsent_IList(list.Count - index.Value),
-
-                _ =>
-                source.InnerElementAtOrAbsent_IEnumerable_FromEnd(index.Value)
-            }
+            _ => index.IsFromEnd is false
+            ? source.InnerElementAtOrAbsent_IEnumerable(index.Value)
+            : source.InnerElementAtOrAbsent_IEnumerable_FromEnd(index.Value)
         };
 
     private static Optional<TSource> InnerElementAtOrAbsent<TSource>(

--- a/src/core-taggeds/Taggeds/Taggeds.csproj
+++ b/src/core-taggeds/Taggeds/Taggeds.csproj
@@ -17,7 +17,7 @@
     <Description>PrimeFuncPack Core.Taggeds is a core pack for .NET consisting of fundamental tagged types targeted for use in functional programming: Optional and Result monads, Tagged Union, as well as the convert extensions.</Description>
     <RootNamespace>System</RootNamespace>
     <AssemblyName>PrimeFuncPack.Core.Taggeds</AssemblyName>
-    <Version>2.2.0-preview.6</Version>
+    <Version>2.2.0-preview.7</Version>
   </PropertyGroup>
 
   <ItemGroup>
@@ -33,7 +33,7 @@
 
   <ItemGroup>
     <PackageReference Include="PrimeFuncPack.Core.Failure" Version="2.1.0" />
-    <PackageReference Include="PrimeFuncPack.Core.Optional" Version="2.2.0-preview.2" />
+    <PackageReference Include="PrimeFuncPack.Core.Optional" Version="2.2.0-preview.3" />
     <PackageReference Include="PrimeFuncPack.Core.Result" Version="2.1.0-preview.3" />
     <PackageReference Include="PrimeFuncPack.Core.TaggedUnion" Version="2.1.0-preview.2" />
     <PackageReference Include="PrimeFuncPack.Core.Unit" Version="2.2.0" />


### PR DESCRIPTION
`Optional`:
- Improve working with `Index` in `Optional.Linq` (use `Index.GetOffset`, unify the code)
- v2.2.0-preview.3

`Taggeds`
- v2.2.0-preview.7
- release/v2.2.0-preview.7